### PR TITLE
Feature python3.12 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ Thumbs.db
 
 # Windows specific leftover:
 doc/tmp.sv
+test-reports/results.xml

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,9 +1,8 @@
 ------------------------------------------------------------------------------
-  qPython 3.2.0 [2024.08.23]
+  qPython 3.1.1 [2024.08.23]
 ------------------------------------------------------------------------------
- - Python 3.12 support
- - Fix for `fastutils.pyx` - where `uncompress()` was interpreted due to underlying Numpy exception
- - Python 3.12 compatibility was tested by running successful `tox` command in local development environment
+ - Compatibility with Python 3.12
+ - Fix: cythonized version of decompression
 
 ------------------------------------------------------------------------------
   qPython 3.1.0 [2024.07.23]

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,11 @@
 ------------------------------------------------------------------------------
+  qPython 3.2.0 [2024.08.23]
+------------------------------------------------------------------------------
+ - Python 3.12 support
+ - Fix for `fastutils.pyx` - where `uncompress()` was interpreted due to underlying Numpy exception
+ - Python 3.12 compatibility was tested by running successful `tox` command in local development environment
+
+------------------------------------------------------------------------------
   qPython 3.1.0 [2024.07.23]
 ------------------------------------------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ qPython is a Python library providing support for interprocess communication bet
 - Support for kdb+ protocol and types: v3.0, v2.6, v<=2.5
 - Uncompression of the IPC data stream
 - Internal representation of data via numpy arrays (lists, complex types) and numpy data types (atoms)
-- Supported on Python 3.7/3.8/3.9/3.10/3.11 and numpy 1.14+
+- Supported on Python 3.7/3.8/3.9/3.10/3.11/3.12 and numpy 1.14+
 
 For more details please refer to the `documentation`_.
 
@@ -51,7 +51,7 @@ Build binary distribution
 
 Instructions:
 
-- Execute: ``python setup.py bdist``
+- Execute: ``python setup.py bdist`` or more modern way: ``python setup.py bdist_wheel``
 
 
 Testing

--- a/qpython/__init__.py
+++ b/qpython/__init__.py
@@ -17,7 +17,7 @@
 __all__ = ['qconnection', 'qtype', 'qtemporal', 'qcollection']
 
 
-__version__ = '3.1.0'
+__version__ = '3.2.0'
 
 
 from copy import deepcopy

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,8 @@ setup(name='qPython',
           'Programming Language :: Python :: 3.8',
           'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: 3.10',
-          'Programming Language :: Python :: 3.11'
+          'Programming Language :: Python :: 3.11',
+          'Programming Language :: Python :: 3.12'
           'Topic :: Database :: Front-Ends',
           'Topic :: Scientific/Engineering',
           'Topic :: Software Development',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = python3.7,python3.8,python3.9,python3.10,python3.11
+envlist = python3.7,python3.8,python3.9,python3.10,python3.11,python3.12
 
 [testenv]
 # install pytest in the virtualenv where commands will be executed


### PR DESCRIPTION
# qpython==3.2.0
## Changes
 - Python 3.12 support
 - Fix for `fastutils.pyx` - where `uncompress()` was interpreted instead of being compiled, due to underlying Numpy exception - fixed in commit https://github.com/bigxyt/qPython/commit/2e267c8dfdf7ed48b8f1181b960602e2000e9367, issue details: https://github.com/bigxyt/market-data-api/issues/443#issuecomment-2304622937
## Tests
 - Python 3.12 compatibility was tested by running successful `tox` command in local development environment
 - Package can be built and installed with no issues