### PR TITLE
Distutils replacement

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -1,5 +1,5 @@
 numpy>=1.14
 pytest>=2.5.0
-setuptools==73.0.1
 cython>=0.20
 numpy>=1.14
+setuptools

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -1,3 +1,5 @@
 numpy>=1.14
 pytest>=2.5.0
 setuptools==73.0.1
+cython>=0.20
+numpy>=1.14

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -1,5 +1,2 @@
 numpy>=1.14
 pytest>=2.5.0
-cython>=0.20
-numpy>=1.14
-setuptools

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -1,2 +1,3 @@
 numpy>=1.14
 pytest>=2.5.0
+setuptools==73.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pandas>=1.2
 numpy>=1.14
 pytest>=2.5.0
 twisted>=13.2.0
-setuptools==73.0.1
+setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas>=1.2
 numpy>=1.14
 pytest>=2.5.0
 twisted>=13.2.0
+setuptools==73.0.1

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 import os
 import sys
 
-from distutils.core import setup
+from setuptools import setup
 
 from qpython import __version__
 


### PR DESCRIPTION
## Changes
 - Replace deprecated `distutils` with `setuptools`.
 - Added support for dynamic requirements installation, during distribution pipeline build.
 - This change allows https://github.com/bigxyt/qPython-ci/issues/1 issue to be solved.